### PR TITLE
Add support for TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .hubot_history
 .node-version
+/test-types/**/*.js

--- a/package.json
+++ b/package.json
@@ -27,23 +27,27 @@
     "scoped-http-client": "0.11.0"
   },
   "devDependencies": {
-    "hubot-mock-adapter": "^1.0.0",
+    "@types/node": "^8.0.34",
+    "chai": "~2.1.0",
     "coffee-errors": "0.8.6",
+    "hubot-mock-adapter": "^1.0.0",
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
-    "sinon-chai": "^2.8.0",
     "sinon": "~1.17.0",
-    "chai": "~2.1.0"
+    "sinon-chai": "^2.8.0",
+    "typescript": "^2.5.3"
   },
   "engines": {
     "node": ">= 0.8.x",
     "npm": ">= 1.1.x"
   },
   "main": "./index",
+  "types": "./types/index.d.ts",
   "bin": {
     "hubot": "./bin/hubot"
   },
   "scripts": {
-    "test": "./script/test"
+    "test": "./script/test",
+    "test:types": "tsc -p ./test-types/tsconfig.json"
   }
 }

--- a/test-types/index.ts
+++ b/test-types/index.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+import {
+  Robot,
+  OnSend,
+  WithReadStatusProperties, WithOnReadStatusHandler,
+  YesNo, SentYesNo,
+  Text, SentText,
+  TaskClosingType,
+  ResponseWithJson, RemoteFile, RemoteFiles,
+} from "../types";
+
+exports = (robot: Robot) => {
+  robot.send({room: "id"}, "トークを指定して送信");
+
+  robot.respond(/send/i, res => {
+    res.send("テキスト");
+    res.send({text: "テキスト"});
+    res.send({stamp_set: "3", stamp_index: "1152921507291203198"});
+    res.send({stamp_set: "3", stamp_index: "1152921507291203198", text: "テキスト付き"});
+    res.send({question: "Yes No 質問"});
+    res.send({close_yesno: "yesno message id"});
+    res.send({question: "Select 質問", options: ["A", "B", "C"]});
+    res.send({close_select: "select message id"});
+    res.send({title: "タスク", closing_type: TaskClosingType.Any});
+    res.send({close_task: "task message id"});
+    res.send({path: "/path/to/file", name: "添付ファイル", type: "text/plain", text: "先ほどの議事録です"});
+    res.send({path: ["/path/to/image1", "/path/to/image2"], type: ["image/png", "image/png"]});
+  });
+
+  robot.respond(/text (.*)/i, res => {
+    res.send(`echo ${res.match[1]}`);
+
+    const c1: Text & WithReadStatusProperties<SentText> = {
+      text: "返答",
+      onread: () => true,
+      onsend: (sent) => {
+        console.log(sent.message.content.text);
+        console.log(sent.readUsers);
+        console.log(sent.unreadUsers);
+      }
+    };
+    res.send(c1);
+
+    const c2: Text & WithOnReadStatusHandler<SentText> = {
+      text: "返答",
+      onread: (nows, reads, unreads) => {
+        console.log(nows);
+      },
+      onsend: (sent) => {
+        console.log(sent.message.content.text);
+      }
+    };
+    res.send(c2);
+  });
+
+  robot.respond("stamp", res => {
+    res.send(`${res.json.stamp_set} - ${res.json.stamp_index}`);
+  });
+  robot.respond("yesno", res => {
+    if (res.json.response) {
+      res.json.response;
+    } else {
+      res.json.question;
+    }
+    res.send({in_reply_to: res.message.id, response: true});
+  });
+  robot.respond("select", res => {
+    if (res.json.response) {
+      res.json.options[res.json.response];
+    } else {
+      res.json.question;
+      res.json.options;
+    }
+    res.send({in_reply_to: res.message.id, response: 0});
+  });
+  robot.respond("task", res => {
+    if (res.json.done) {
+      res.json.done;
+    } else {
+      res.json.title;
+      res.json.closing_type;
+    }
+    res.send({in_reply_to: res.message.id, done: true});
+  });
+
+  const onFile = (res: ResponseWithJson<RemoteFile | RemoteFiles>, file: RemoteFile): void => {
+    file.name;
+    file.content_type;
+    file.content_size;
+    res.download(file, path => {
+      console.log(`downloaded to ${path}`);
+    });
+  };
+  robot.respond("file", res => {
+    onFile(res, res.json);
+  });
+  robot.respond("files", res => {
+    res.json.files.forEach(f => onFile(res, f));
+  })
+
+  robot.respond("map", res => {
+    res.json.place;
+    res.json.lat;
+    res.json.lng;
+  });
+
+  robot.respond(/yesno answers/i, res => {
+    const cs: YesNo & OnSend<SentYesNo> = {
+      question: "質問",
+      onsend: (sent) => {
+        sent.message.content.question;
+        sent.message.content.listing;
+        sent.answer((trues, falses) => {
+          console.log(trues);
+        });
+      }
+    };
+    res.send(cs);
+  });
+
+  robot.respond(/yesno read properties/i, res => {
+    const cs: YesNo & WithReadStatusProperties<SentYesNo> = {
+      question: "質問",
+      onread: () => true,
+      onsend: (sent) => {
+        sent.readUsers;
+        sent.unreadUsers;
+        sent.answer((trues, falses) => {
+          console.log(trues);
+        });
+      }
+    };
+    res.send(cs);
+  });
+
+  robot.respond(/yesno read handler/i, res => {
+    const cs: YesNo & WithOnReadStatusHandler<SentYesNo> = {
+      question: "質問",
+      onread: (nows, reads, unreads) => {
+        console.log(nows);
+      },
+      onsend: (sent) => {
+        sent.answer((trues, falses) => {
+          console.log(trues);
+        });
+      }
+    };
+    res.send(cs);
+  });
+
+  robot.respond(/goodbye/i, res => {
+    res.leave();
+  });
+  robot.respond(/banned word/, res => {
+    res.leave(res.message.user);
+  });
+
+  robot.respond(/announce (.*)/, res => {
+    res.announce(res.match[1]);
+  });
+}

--- a/test-types/tsconfig.json
+++ b/test-types/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "node_modules/*",
+        "types/*"
+      ]
+    }
+  },
+  "include": [
+    "*.ts"
+  ]
+}

--- a/types/brain.d.ts
+++ b/types/brain.d.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+import { DirectDomain, DirectTalk, DirectUser } from "./direct";
+
+export interface Brain {
+  data: {
+    users: {[id: string]: DirectUser};
+    talks: {[id: string]: DirectTalk};
+    domains: {[id: string]: DirectDomain};
+    _private: object;
+  };
+  autoSave: boolean;
+
+  set(key: string, value: any): Brain;
+  set(obj: object): Brain;
+  get(key: string): any | undefined;
+  remove(key: string): Brain;
+
+  save(): void;
+  close(): void;
+
+  setAutoSave(enabled: boolean): void;
+  resetSaveInterval(seconds: number): void;
+
+  mergeData(data: object): void;
+
+  users(): {[id: string]: DirectUser};
+  userForId(id: string, options?: object): DirectUser | any; // NOTE: get or create
+  userForName(name: string): DirectUser[] | null;
+  usersForRawFuzzyName(fuzzyName: string): DirectUser[];
+  usersForFuzzyName(fuzzyName: string): DirectUser[];
+
+  rooms(): {[id: string]: DirectTalk};
+  domains(): {[id: string]: DirectDomain};
+}

--- a/types/direct/index.d.ts
+++ b/types/direct/index.d.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+
+export interface Int64 {
+  high: number;
+  low: number;
+}
+
+export interface DirectUser {
+  id: string;
+  id_i64: Int64;
+  name: string;
+  displayName: string;
+  canonicalDisplayName: string;
+  phoneticDisplayName: string | null;
+  canonicalPhoneticDisplayName: string | null;
+  email?: string;
+  profile_url?: string;
+  updatedAt: Int64;
+}
+
+export interface DirectDomain {
+  id: string;
+  id_i64: Int64;
+  domainInfo: {
+    name: string,
+    logoUrl: string | null,
+    frozen: boolean
+  },
+  closed: boolean;
+  contract: any; // TODO
+  profileDefinition: any; // TODO
+  setting: any; // TODO
+  role: any; // TODO
+}
+
+export enum DirectTalkType {
+  Unknown = 0,
+  Pair = 1,
+  Group = 2,
+}
+
+export interface DirectTalk {
+  id: string;
+  id_i64: Int64;
+  domainId: string;
+  domainId_i64: Int64;
+  type: DirectTalkType;
+  name: string | null;
+  topic: string | null;
+  iconUrl: string | null;
+  userIds: Int64[];
+  guestIds: null;
+  leftUsers: any[]; // TODO
+  users: DirectUser[];
+  domain: DirectDomain;
+  updatedAt: Int64;
+}

--- a/types/http.d.ts
+++ b/types/http.d.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+
+export type HttpHeaderName = "Accept" | "Authorization" | "Content-Type";
+
+export type HttpHeaders = {[n in HttpHeaderName]?: string};
+
+export type HttpClientResponseHandler = (err: any, res: any, body: any) => void;
+
+export interface HttpClient {
+  header(name: HttpHeaderName, value: string): HttpClient;
+  headers(hs: HttpHeaders): HttpClient;
+  query(ps: {[key: string]: string | number}): HttpClient;
+
+  get(): (callback: HttpClientResponseHandler) => void;
+  post(data: any): (callback: HttpClientResponseHandler) => void;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+
+export * from "./direct";
+export * from "./brain";
+export * from "./http";
+export * from "./message";
+export * from "./response";
+export * from "./robot";

--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+import { DirectTalk, DirectTalkType, DirectUser } from "./direct";
+
+export interface User extends DirectUser {
+  room: string;
+  rooms: DirectTalk[];
+}
+
+export interface Message {
+  user: User;
+  room: string;
+  roomType: DirectTalkType;
+  roomTopic: string;
+  roomUsers: User[];
+  rooms: {[id: string]: DirectTalk};
+}
+
+export type MessageId = string;
+
+export interface TextMessage extends Message {
+  text: string;
+  id: MessageId;
+}
+
+export interface EnterMessage extends Message {}
+export interface LeaveMessage extends Message {}
+export interface TopicMessage extends Message {}
+export interface JoinMessage extends Message {}
+
+// a message that no matchers matched
+export interface CatchAllMessage extends Message {
+  message: any; // the original message
+}

--- a/types/response.d.ts
+++ b/types/response.d.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+import { DirectUser } from "./direct";
+import { HttpClient } from "./http";
+import { Message, MessageId, TextMessage, User } from "./message";
+import { Robot } from "./robot";
+
+export interface Response<M extends Message> {
+  robot: Robot;
+  message: M;
+  match: RegExpMatchArray;
+  envelope: {room: string, user: User, message: M};
+
+  send(...content: SendableContent[]): void;
+  download(file: RemoteFile, callback: (path: string) => void): void;
+  announce(...content: string[]): void;
+  leave(user?: {id: string}): void;
+  http(url: string, options: object): HttpClient;
+}
+
+export interface ResponseWithJson<T extends JsonContent> extends Response<TextMessage> {
+  json: T;
+}
+
+// type definitions
+
+export type SelectResponse = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export declare enum TaskClosingType { Any = 0, All = 1 }
+
+export type SendableContent = 
+    string
+  | Text
+  | Text   & SendTextHandler
+  | Stamp
+  | Stamp  & SendStampHandler
+  | YesNo
+  | YesNo  & SendYesNoHandler
+  | Select
+  | Select & SendSelectHandler
+  | Task
+  | Task   & SendTaskHandler
+  | CloseYesNo | CloseSelect | CloseTask
+  | AttachmentFile | AttachmentFiles
+  | ReplyResponse<boolean> | ReplyResponse<SelectResponse> | ReplyTask
+  ;
+
+export type Text         = {text: string}
+export type Stamp        = {stamp_set: string, stamp_index: string, text?: string};
+export type YesNo        = {question: string};
+export type CloseYesNo   = {close_yesno: MessageId};
+export type Select       = {question: string, options: string[]};
+export type CloseSelect  = {close_select: MessageId};
+export type Task         = {title: string, closing_type: TaskClosingType};
+export type CloseTask    = {close_task: MessageId};
+
+export type AttachmentFile = {
+  path:  string;
+  name?: string;
+  type?: string;
+  text?: string;
+};
+export type AttachmentFiles = {
+  path:  string[];
+  name?: string[];
+  type?: string[];
+  text?: string;
+};
+export type ReplyResponse<R> = {in_reply_to: MessageId, response: R};
+export type ReplyTask        = {in_reply_to: MessageId, done: boolean};
+
+export type SentText   = Sent<Text>;
+export type SentStamp  = Sent<Stamp>;
+export type SentYesNo  = SentAction<YesNoAnswer, YesNo>;
+export type SentSelect = SentAction<SelectAnswer, Select>;
+export type SentTask   = SentAction<TaskAnswer, Task>;
+
+type YesNoAnswer  = (trues: DirectUser[], falses: DirectUser[]) => void;
+type SelectAnswer = (options: Array<DirectUser[]>) => void;
+type TaskAnswer   = (dones: DirectUser[], undones: DirectUser[]) => void;
+
+type SendTextHandler   = OnSend<SentText>   | WithOnReadStatusHandler<SentText>   | WithReadStatusProperties<SentText>;
+type SendStampHandler  = OnSend<SentStamp>  | WithOnReadStatusHandler<SentStamp>  | WithReadStatusProperties<SentStamp>;
+type SendYesNoHandler  = OnSend<SentYesNo>  | WithOnReadStatusHandler<SentYesNo>  | WithReadStatusProperties<SentYesNo>;
+type SendSelectHandler = OnSend<SentSelect> | WithOnReadStatusHandler<SentSelect> | WithReadStatusProperties<SentSelect>;
+type SendTaskHandler   = OnSend<SentTask>   | WithOnReadStatusHandler<SentTask>   | WithReadStatusProperties<SentTask>;
+
+export type WithOnReadStatusHandler<S> =
+  OnRead<(readNowUsers: DirectUser[], readUsers: DirectUser[], unreadUsers: DirectUser[]) => void> &
+  OnSend<S>;
+export type WithReadStatusProperties<S> =
+  OnRead<() => true> &
+  OnSend<S & {readUsers: DirectUser[], unreadUsers: DirectUser[]}>;
+type OnRead<H> = {onread: H};
+type OnSend<S> = {onsend: (sent: S) => void};
+
+type Sent<C>          = {message: SentMessage<C>};
+type SentAction<H, C> = Sent<C & {listing: boolean}> & {answer: SentAnswer<H>};
+type SentAnswer<H>    = (cb: H) => void;
+type SentMessage<C>   = {id: MessageId, type: number, content: C};
+
+export type JsonContent =
+    Stamp
+  | YesNoWithResponse | SelectWithResponse | TaskWithResponse
+  | RemoteFile | RemoteFiles
+  | ActualLocation
+  ;
+
+export type YesNoWithResponse  = YesNo & {response?: boolean};
+export type SelectWithResponse = Select & {response?: SelectResponse};
+export type TaskWithResponse   = Task & {done?: boolean}
+
+export type RemoteFile = {
+  name: string;
+  content_type: string;
+  content_size: number;
+};
+export type RemoteFiles = {
+  files: RemoteFile[];
+  text?: string;
+};
+
+export type ActualLocation = {
+  place: string;
+  lat: number;
+  lng: number;
+};

--- a/types/robot.d.ts
+++ b/types/robot.d.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 Sho Kuroda <krdlab@gmail.com>
+// Released under the MIT license.
+import { Brain } from "./brain";
+import { HttpClient } from "./http";
+import { User, Message, MessageId, TextMessage, EnterMessage, LeaveMessage, JoinMessage, TopicMessage, CatchAllMessage } from "./message";
+import { Response, ResponseWithJson, Stamp, YesNoWithResponse, SelectWithResponse, TaskWithResponse, RemoteFile, RemoteFiles, ActualLocation, SendableContent, JsonContent } from "./response";
+
+export type Matcher = (msg: Message) => boolean;
+export type Callback<M extends Message> = (res: Response<M>) => void;
+export type ErrorHandler = (err: Error, res: object) => void;
+
+export type RespondType = "stamp" | "yesno" | "select" | "task" | "file" | "files" | "map";
+export type TypedJsonCallback<T extends RespondType, J extends JsonContent> = (res: ResponseWithJson<J>) => void;
+
+export interface Robot {
+  brain: Brain;
+
+  listen<M extends Message>(matcher: Matcher, options: object, callback: Callback<M>): void;
+
+  hear(regex: RegExp, callback: Callback<TextMessage>): void;
+  respond(regex: RegExp, callback: Callback<TextMessage>): void;
+
+  respond(type: "stamp", callback: TypedJsonCallback<"stamp", Stamp>): void;
+  respond(type: "yesno", callback: TypedJsonCallback<"yesno", YesNoWithResponse>): void;
+  respond(type: "select", callback: TypedJsonCallback<"select", SelectWithResponse>): void;
+  respond(type: "task", callback: TypedJsonCallback<"task", TaskWithResponse>): void;
+  respond(type: "file", callback: TypedJsonCallback<"file", RemoteFile>): void;
+  respond(type: "files", callback: TypedJsonCallback<"files", RemoteFiles>): void;
+  respond(type: "map", callback: TypedJsonCallback<"map", ActualLocation>): void;
+
+  enter(callback: Callback<EnterMessage>): void;
+  leave(callback: Callback<LeaveMessage>): void;
+  join(callback: Callback<JoinMessage>): void;
+  topic(callback: Callback<TopicMessage>): void;
+  error(callback: ErrorHandler): void;
+  catchAll(callback: Callback<CatchAllMessage>): void;
+
+  send(envelope: {room: string}, ...contents: SendableContent[]): void;
+  reply(envelope: {room: string, user: User}, ...contents: SendableContent[]): void;
+  announce(domain: {id: string}, ...contents: string[]): void;
+
+  http(url: string, options: object): HttpClient;
+}


### PR DESCRIPTION
lisb-hubot の TypeScript 用型宣言ファイルを定義しました．

この型宣言を利用してコードを書くと，存在しないフィールドを利用したり，指定するべき値の型が一致しなかったりした場合にコンパイルエラーとして検出することが可能です．

テストコマンドとして `npm run test:types` を追加しています．

`daab init` したプロジェクトで TypeScript による開発をはじめたいときは以下のようにします．

1. lisb-hubot のバージョンを上げる
1. `npm install —save-dev typescript`
1. tsconfig.json を作成
    ```json
    {
      "compilerOptions": {
        "module": "commonjs",
        "target": "es6",
        "noImplicitAny": true,
        "strictNullChecks": true,
        "moduleResolution": "node",
        "sourceMap": true,
        "outDir": "./scripts",
        "baseUrl": ".",
        "paths": {
          "*": [
            "node_modules/*"
          ]
        }
      },
      "include": [
        "src/**/*.ts"
      ]
    }
    ```
1. ボットプロジェクトの `package.json` の scripts に `"build": "tsc"` を追加
1. コードを `src/*.ts` に書く
1. `npm run build && daab run`

サンプルコードは `test-types/index.ts` をご覧ください．