### PR TITLE
ノートイベントを respond, hear 可能にする

### DIFF
--- a/src/robot-direct.js
+++ b/src/robot-direct.js
@@ -50,6 +50,12 @@ const jsonMatcher = (prop, options, callback) => {
         return !!obj.title
       case 'file':
         return !!obj.file_id
+      case 'note_created':
+        return !!obj.note_id && !!obj.revision && obj.revision === 1
+      case 'note_updated':
+        return !!obj.note_id && !!obj.revision && obj.revision > 1
+      case 'note_deleted':
+        return !!obj.note_id && obj.revision == null
       default:
         return !!obj[prop]
     }


### PR DESCRIPTION
```javascript
  robot.hear('note_created', (res) => {
    ...

  robot.hear('note_updated', (res) => {
    ...

  robot.hear('note_deleted', (res) => {
    ...
```

```javascript
// note_created
{ title: 'ノートイベント確認', note_id: '_246955267_1782579200' }

// note_updated
{ title: 'ノートイベント確認', note_id: '_246955267_1782579200' }

// note_deleted
{ title: 'ノートイベント確認', note_id: '_246955267_1782579200' }
```

----

~~`types` の修正は別 PR を出します → [作業ブランチ](https://github.com/lisb/hubot/tree/feature/add-type-declaration-for-note)~~
→ 出しました #11 